### PR TITLE
Tenji240/Font Awesome upgrade to v5.4.1

### DIFF
--- a/kitchensink/index.html
+++ b/kitchensink/index.html
@@ -16,7 +16,6 @@
 
     <!-- CUSTOM CSS ONLY FOR THIS KITCHEN SINK -->
     <link media="screen" href="./kitchensink.css" rel="stylesheet" />
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
 
   </head>
   <body>
@@ -503,11 +502,11 @@
                           <ul id="tagsExample" class="list-unstyled">
                             <li class="tag tag-default">
                               Assignment
-                              <a href="#" class="fas fa-close fa-muted" data-dismiss="tag" aria-label="Close"></a>
+                              <a href="#" class="fas fa-times fa-muted" data-dismiss="tag" aria-label="Close"></a>
                             </li>
                             <li class="tag tag-default">
                               Change of name
-                              <a href="#" class="fas fa-close fa-muted" data-dismiss="tag" aria-label="Close"></a>
+                              <a href="#" class="fas fa-times fa-muted" data-dismiss="tag" aria-label="Close"></a>
                             </li>
                           </ul>
                           <div class="input-group">
@@ -2472,7 +2471,7 @@
                   </button>
                   <p></p>
                   <button aria-label="favorite_button_label" class="btn btn-default btn-icon-only">
-                  <i class="fas fa-star-o"></i>
+                  <i class="fas fa-star"></i>
                   </button>
                   <button aria-label="disabled_button_label" class="btn btn-default btn-icon-only" disabled>
                   <i class="fas fa-spinner fa-pulse"></i>
@@ -2808,31 +2807,31 @@
                   <ul class="list-unstyled">
                     <li class="tag tag-default">
                       Default
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-inverse">
                       Inverse
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-primary">
                       Primary
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-info">
                       Info
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-warning">
                       Warning
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-danger">
                       Danger
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-success">
                       Success
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                   </ul>
                 </div>
@@ -2844,27 +2843,27 @@
                   <ul class="list-unstyled">
                     <li class="tag tag-default subtle">
                       Default
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-primary subtle">
                       Primary
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-info subtle">
                       Info
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-warning subtle">
                       Warning
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-danger subtle">
                       Danger
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-success subtle">
                       Success
-                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-times fa-muted" data-dismiss="tag"></a>
                     </li>
                   </ul>
                 </div>
@@ -2902,7 +2901,7 @@
                               <!-- timeline icon -->
                               <i class="fas fa-envelope"></i>
                               <div class="timeline-item">
-                                  <span class="time"><i class="fas fa-clock-o"></i> 12:05</span>
+                                  <span class="time"><i class="fas fa-clock"></i> 12:05</span>
 
                                   <h3 class="timeline-header"><a href="#">Event #1</a> ...</h3>
 
@@ -2938,7 +2937,7 @@
                               <!-- timeline icon -->
                               <i class="timepoint-text">Event 1</i>
                               <div class="timeline-item">
-                                  <span class="time"><i class="fas fa-clock-o"></i> 12:15</span>
+                                  <span class="time"><i class="fas fa-clock"></i> 12:15</span>
 
                                   <h3 class="timeline-header"><a href="#">Event with no icon</a> ...</h3>
 
@@ -2956,7 +2955,7 @@
                           <!-- END timeline item -->
 
                           <li>
-                            <i class="fas fa-clock-o"></i>
+                            <i class="fas fa-clock"></i>
                           </li>
                         </ul>
                       </div>
@@ -2979,7 +2978,7 @@
 
 
                           <li>
-                            <i class="fas fa-files-o"></i>
+                            <i class="fas fa-copy"></i>
                             <div class="timeline-item">
                               <span class="time">2 filings <i class="fas fa-info-circle"></i></span>
 
@@ -3010,7 +3009,7 @@
                           </li>
 
                           <li>
-                            <i class="fas fa-sticky-note-o"></i>
+                            <i class="fas fa-sticky-note"></i>
                             <div class="timeline-item">
                               <span class="time">7 related notes <i class="fas fa-info-circle"></i></span>
 
@@ -3038,7 +3037,7 @@
 
 
                           <li>
-                            <i class="fas fa-circle-o-notch"></i>
+                            <i class="fas fa-circle-notch"></i>
                             <div class="timeline-item">
                               <span class="time">1 event <i class="fas fa-info-circle"></i></span>
 
@@ -3048,7 +3047,7 @@
 
 
                           <li>
-                            <i class="fas fa-clock-o"></i>
+                            <i class="fas fa-clock"></i>
                           </li>
                         </ul>
                       </div>
@@ -3078,7 +3077,7 @@
                             <i class="fas fa-envelope"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fas fa-clock-o"></i> 12:05</span>
+                              <span class="time"><i class="fas fa-clock"></i> 12:05</span>
 
                               <h3 class="timeline-header"><a href="#">Event #1</a> sent you an email</h3>
 
@@ -3098,7 +3097,7 @@
                             <i class="fas fa-user"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fas fa-clock-o"></i> 5 mins ago</span>
+                              <span class="time"><i class="fas fa-clock"></i> 5 mins ago</span>
 
                               <h3 class="timeline-header no-border"><a href="#">Sarah Young</a> accepted your friend request</h3>
                             </div>
@@ -3110,7 +3109,7 @@
                             <i class="fas fa-comments"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fas fa-clock-o"></i> 27 mins ago</span>
+                              <span class="time"><i class="fas fa-clock"></i> 27 mins ago</span>
 
                               <h3 class="timeline-header"><a href="#">Jay White</a> commented on your post</h3>
 
@@ -3137,7 +3136,7 @@
                             <i class="fas fa-camera"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fas fa-clock-o"></i> 2 days ago</span>
+                              <span class="time"><i class="fas fa-clock"></i> 2 days ago</span>
 
                               <h3 class="timeline-header"><a href="#">Mina Lee</a> uploaded new photos</h3>
 
@@ -3152,7 +3151,7 @@
                           <!-- END timeline item -->
 
                           <li>
-                            <i class="fas fa-clock-o"></i>
+                            <i class="fas fa-clock"></i>
                           </li>
                         </ul>
                       </div>
@@ -3189,7 +3188,7 @@
                       <div>
                         <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Print">Short</button>
                         <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" data-html="true" title='Lorem ipsum dolor sit amet, consectetur adipiscing elit. In semper volutpat ultrices. Mauris lobortis lacus vel ullamcorper vestibulum.'>Wrapping</button>
-                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" data-html="true" title='<i class="fas fa-inverse fa-calendar-o"></i> <strong>January 21</strong> , 2014'>
+                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" data-html="true" title='<i class="fas fa-inverse fa-calendar"></i> <strong>January 21</strong> , 2014'>
                           Rich content
                         </button>
                       </div>

--- a/kitchensink/index.html
+++ b/kitchensink/index.html
@@ -26,7 +26,7 @@
         <div class="container-fluid">
           <div class="navbar-header">
             <a class="navbar-brand" href="../">
-              <span class="visible-md visible-lg"><span class="cbp-brand">Organization Brand - CBP Theme 1.0</span></span>
+              <span class="visible-md visible-lg"><span class="cbp-brand">Organization Brand - CBP Theme 1.1</span></span>
               <span class="visible-xs visible-sm"><span class="cbp-brand">Brand</span></span>
               <span class="visible-md visible-lg"><span class="dhs-brand">Organization Sub Branding</span></span>
             </a>
@@ -355,7 +355,7 @@
                       </div>
                     </div>
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup2" aria-controls="filterGroup2" class="filter-group-title">
-                      <a name="#cbp-sidebar"><i class="fas fa-angle-double-right pull-right"></i></a>
+                      <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a>
                     Mode of Transportation
                     </h3>
                     <div id="filterGroup2" class="collapse in">

--- a/kitchensink/index.html
+++ b/kitchensink/index.html
@@ -52,13 +52,13 @@
             <ul class="hidden-xs nav navbar-nav navbar-right">
               <li>
                 <a href="#cbp-header">
-                  <span class="fa fa-comment"></span>
+                  <span class="fas fa-comment"></span>
                   <span class="hidden-sm">Feedback</span>
                 </a>
               </li>
               <li data-toggle="hover" class="dropdown">
                 <a href="" data-toggle="dropdown" class="dropdown-toggle">
-                  <span class="fa fa-user"></span>
+                  <span class="fas fa-user"></span>
                   <span class="hidden-sm" title="FIRST.LAST@CBP.DHS.GOV">First Last Name</span>
                   <span class="caret"></span>
                 </a>
@@ -83,7 +83,7 @@
                   </li>
                   <li>
                     <button class="btn">
-                      <i class="fa fa-sign-out fa-fw"></i>
+                      <i class="fas fa-sign-out fa-fw"></i>
                       <a title="Logout" href="#user-menu">Not you? Click to Logout</a>
                     </button>
                   </li>
@@ -97,7 +97,7 @@
                 </li>
                 <li class="list-group-item">
                   <button class="btn">
-                    <i class="fa fa-sign-out fa-fw"></i>
+                    <i class="fas fa-sign-out fa-fw"></i>
                     <a title="Logout" href="#user-menu">Not you? Click to Logout</a>
                   </button>
                 </li>
@@ -109,7 +109,7 @@
                     <div class="panel">
                       <div class="panel-heading" role="tab" id="2headingOne">
                         <h3 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseOne" aria-expanded="false" aria-controls="2collapseOne" class="collapsed"><i class="fa fa-angle-right"></i>
+                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseOne" aria-expanded="false" aria-controls="2collapseOne" class="collapsed"><i class="fas fa-angle-right"></i>
                         &nbsp;Application Directory</a>
                         </h3>
                       </div>
@@ -139,7 +139,7 @@
                       <div class="panel-heading" role="tab" id="2headingTwo">
                         <h3 class="panel-title">
                         <a role="button" href="#cbp-header" >
-                          <i class="fa fa-comment"></i>
+                          <i class="fas fa-comment"></i>
                         &nbsp;Feedback</a>
                         </h3>
                       </div>
@@ -148,8 +148,8 @@
                       <div class="panel-heading" role="tab" id="2headingTwo">
                         <h3 class="panel-title">
                         <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseThree" aria-expanded="false" aria-controls="2collapseTwo" class="collapsed">
-                          <i class="fa fa-angle-right"></i>
-                          <i class="fa fa-user fa-fw"></i>
+                          <i class="fas fa-angle-right"></i>
+                          <i class="fas fa-user fa-fw"></i>
                           Preferences</a>
                         </h3>
                       </div>
@@ -244,7 +244,7 @@
                       <input type="text" id="main-search" class="mdl-textfield__input" />
                     </div>
                     <span class="input-group-btn">
-                      <button aria-label="Search" type="submit" class="btn btn-primary"><i class="fa fa-search"></i></button>
+                      <button aria-label="Search" type="submit" class="btn btn-primary"><i class="fas fa-search"></i></button>
                     </span>
                   </div>
                 </div>
@@ -284,7 +284,7 @@
                     <li class="divider"></li>
                     <li class="dropdown" role="presentation">
                       <a href="#pane1">View Link Dropdown
-                        <i class="fa fa-caret-right pull-right"></i>
+                        <i class="fas fa-caret-right pull-right"></i>
                       </a>
                       <a class="pull-right" href="#pane1"  type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <span class="sr-only">Toggle Dropdown</span>
@@ -317,7 +317,7 @@
                     </div>
                     <span class="input-group-btn">
                       <button aria-label="Search" type="submit" class="btn btn-primary">
-                        <i class="fa fa-search"></i>
+                        <i class="fas fa-search"></i>
                       </button>
                     </span>
 
@@ -340,7 +340,7 @@
                     <h1 class="filter-heading">Filters <a href="#cbp-sidebar" class="filters-clear">Clear Filters</a></h1>
 
                     <h2 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup8" aria-controls="filterGroup8" class="filter-group-title">
-                    Year <a name="#sidebar"><i class="fa fa-angle-right pull-right"></i></a>
+                    Year <a name="#sidebar"><i class="fas fa-angle-right pull-right"></i></a>
                     </h2>
                     <div id="filterGroup8" class="collapse in">
                       <div class="filter-group-content">
@@ -355,7 +355,7 @@
                       </div>
                     </div>
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup2" aria-controls="filterGroup2" class="filter-group-title">
-                      <a name="#cbp-sidebar"><i class="fa fa-angle-right pull-right"></i></a>
+                      <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a>
                     Mode of Transportation
                     </h3>
                     <div id="filterGroup2" class="collapse in">
@@ -401,20 +401,20 @@
                       </div>
                     </div>
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup1" aria-controls="filterGroup1" class="filter-group-title">
-                      <a name="#cbp-sidebar"><i class="fa fa-angle-right pull-right"></i></a> Date range
+                      <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a> Date range
                     </h3>
                     <div id="filterGroup1" class="collapse in">
                       <div class="filter-group-content">
                         <div class="row">
                           <div class="form-group col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="startRange" class="mdl-textfield__label"><i class="fa fa-calendar-o fa-fw"></i>&nbsp;Start</label>
+                              <label for="startRange" class="mdl-textfield__label"><i class="fas fa-calendar-o fa-fw"></i>&nbsp;Start</label>
                               <input type="text" id="startRange" class="datepicker mdl-textfield__input" data-inputmask=" 'alias' : 'mdl-mask-datepicker'  " />
                             </div>
                           </div>
                           <div class="form-group col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="endRange" class="mdl-textfield__label"><i class="fa fa-calendar-o fa-fw"></i>&nbsp;End</label>
+                              <label for="endRange" class="mdl-textfield__label"><i class="fas fa-calendar-o fa-fw"></i>&nbsp;End</label>
                               <input type="text" id="endRange" class="datepicker mdl-textfield__input" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " />
                             </div>
                           </div>
@@ -422,7 +422,7 @@
                       </div>
                     </div>
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup5" aria-controls="filterGroup5" class="filter-group-title">
-                      <a name="#cbp-sidebar"><i class="fa fa-angle-right pull-right"></i></a> Distance
+                      <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a> Distance
                     </h3>
                     <div id="filterGroup5" class="collapse in">
                       <div class="filter-group-content">
@@ -438,7 +438,7 @@
                     </div>
 
                     <!-- <div aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup9" class="filter-group-title h4">
-                      <i class="fa fa-angle-right pull-right"></i> Price
+                      <i class="fas fa-angle-right pull-right"></i> Price
                     </div>
                     <div id="filterGroup9" class="collapse in">
                       <div class="filter-group-content">
@@ -455,7 +455,7 @@
                       </div>
                     </div>
                     <div aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup10" class="filter-group-title h4">
-                      <i class="fa fa-angle-right pull-right"></i> Amount
+                      <i class="fas fa-angle-right pull-right"></i> Amount
                     </div>
                     <div id="filterGroup10" class="collapse in">
                       <div class="filter-group-content">
@@ -468,18 +468,18 @@
                       </div>
                     </div> -->
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup6" aria-controls="filterGroup6" class="filter-group-title">
-                    <a name="#cbp-sidebar"><i class="fa fa-angle-right pull-right"></i></a> Name
+                    <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a> Name
                     </h3>
                     <div id="filterGroup6" class="collapse in">
                       <div class="filter-group-content">
                         <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                          <label for="serange" class="mdl-textfield__label"><i class="fa fa-search fa-fw"></i>&nbsp;Search</label>
+                          <label for="serange" class="mdl-textfield__label"><i class="fas fa-search fa-fw"></i>&nbsp;Search</label>
                           <input type="text" id="serange" class="mdl-textfield__input" />
                         </div>
                       </div>
                     </div>
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup3" aria-controls="filterGroup3" class="filter-group-title">
-                      Chart Colors <a name="#cbp-sidebar"><i class="fa fa-angle-right pull-right"></i></a>
+                      Chart Colors <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a>
                     </h3>
                     <div id="filterGroup3" class="collapse in">
                       <div class="filter-group-content">
@@ -494,7 +494,7 @@
                       </div>
                     </div>
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup7" aria-controls="filterGroup7" class="filter-group-title">
-                      Tags <a name="#cbp-sidebar"><i class="fa fa-angle-right pull-right"></i></a>
+                      Tags <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a>
                     </h3>
                     <div id="filterGroup7" class="collapse in">
                       <div class="filter-group-content">
@@ -502,16 +502,16 @@
                           <ul id="tagsExample" class="list-unstyled">
                             <li class="tag tag-default">
                               Assignment
-                              <a href="#" class="fa fa-close fa-muted" data-dismiss="tag" aria-label="Close"></a>
+                              <a href="#" class="fas fa-close fa-muted" data-dismiss="tag" aria-label="Close"></a>
                             </li>
                             <li class="tag tag-default">
                               Change of name
-                              <a href="#" class="fa fa-close fa-muted" data-dismiss="tag" aria-label="Close"></a>
+                              <a href="#" class="fas fa-close fa-muted" data-dismiss="tag" aria-label="Close"></a>
                             </li>
                           </ul>
                           <div class="input-group">
                             <div class="mdl-textfield mdl-js-textfield" style="width: 100%;">
-                              <label for="tag" class="mdl-textfield__label"><i class="fa fa-tag fa-fw"></i>&nbsp;Enter Tag</label>
+                              <label for="tag" class="mdl-textfield__label"><i class="fas fa-tag fa-fw"></i>&nbsp;Enter Tag</label>
                               <input type="text" id="tag" class="mdl-textfield__input" />
                             </div>
                             <span class="input-group-btn">
@@ -529,7 +529,7 @@
           <div id="main-content" class="cbp-sidebar-offset">
 
             <h1 class="page-header">All Components</h1>
-            <p>This is the "Kitchen Sink" of the <a href="https://github.com/US-CBP/cbp-theme">CBP Theme&nbsp;<i class="fa fa-external-link"></i></a>.  It is provided to demonstrate various components in action. For guidance on how best to use the theme's components take a look at the <a href="https://us-cbp.github.io/cbp-style-guide">CBP Style Guide&nbsp;<i class="fa fa-external-link"></i></a>.
+            <p>This is the "Kitchen Sink" of the <a href="https://github.com/US-CBP/cbp-theme">CBP Theme&nbsp;<i class="fas fa-external-link"></i></a>.  It is provided to demonstrate various components in action. For guidance on how best to use the theme's components take a look at the <a href="https://us-cbp.github.io/cbp-style-guide">CBP Style Guide&nbsp;<i class="fas fa-external-link"></i></a>.
 
             <!-- TOC -->
             <h2 id="TOC" class="page-header">Table of Content</h2>
@@ -564,7 +564,7 @@
             <div>
               <h2 id="Accordion" class="page-header"> Accordion
                 <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                  <i class="fa fa-chevron-up bounce"></i>
+                  <i class="fas fa-chevron-up bounce"></i>
                 </a>
               </h2>
               <div class="panel">
@@ -576,7 +576,7 @@
                     <div class="panel panel-default">
                       <div class="panel-heading" role="tab" id="headingOne">
                         <h4 class="panel-title">
-                          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne"><i class="fa fa-angle-right fa-fw"></i>
+                          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne"><i class="fas fa-angle-right fa-fw"></i>
                           Goods/Services</a>
                         </h4>
                       </div>
@@ -591,7 +591,7 @@
                     <div class="panel panel-default">
                       <div class="panel-heading" role="tab" id="headingTwo">
                         <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"><i class="fa fa-angle-right fa-fw"></i>
+                        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"><i class="fas fa-angle-right fa-fw"></i>
                         Mark info</a>
                         </h4>
                       </div>
@@ -606,7 +606,7 @@
                     <div class="panel panel-default">
                       <div class="panel-heading" role="tab" id="headingThree">
                         <h4 class="panel-title">
-                          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree"><i class="fa fa-angle-right fa-fw"></i>
+                          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree"><i class="fas fa-angle-right fa-fw"></i>
                           Owner/Assignment</a>
                         </h4>
                       </div>
@@ -668,7 +668,7 @@
                     <div class="panel">
                       <div class="panel-heading" role="tab" id="2headingOne">
                         <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseOne" aria-expanded="true" aria-controls="2collapseOne"><i class="fa fa-angle-right fa-fw"></i>
+                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseOne" aria-expanded="true" aria-controls="2collapseOne"><i class="fas fa-angle-right fa-fw"></i>
                         Goods/Services</a>
                         </h4>
                       </div>
@@ -683,7 +683,7 @@
                     <div class="panel">
                       <div class="panel-heading" role="tab" id="2headingTwo">
                         <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseTwo" aria-expanded="false" aria-controls="2collapseTwo"><i class="fa fa-angle-right fa-fw"></i>
+                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseTwo" aria-expanded="false" aria-controls="2collapseTwo"><i class="fas fa-angle-right fa-fw"></i>
                         Mark info</a>
                         </h4>
                       </div>
@@ -698,7 +698,7 @@
                     <div class="panel">
                       <div class="panel-heading" role="tab" id="2headingThree">
                         <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseThree" aria-expanded="false" aria-controls="2collapseThree"><i class="fa fa-angle-right fa-fw"></i>
+                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseThree" aria-expanded="false" aria-controls="2collapseThree"><i class="fas fa-angle-right fa-fw"></i>
                         Owner/Assignment</a>
                         </h4>
                       </div>
@@ -761,7 +761,7 @@
             <div>
               <h2 id="Alerts" class="page-header">Alerts
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -913,7 +913,7 @@
             <div>
               <h2 id="Bread Crumbs" class="page-header">Bread Crumbs
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -935,7 +935,7 @@
             <div>
               <h2 id="Buttons" class="page-header">Buttons
                 <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                  <i class="fa fa-chevron-up bounce"></i>
+                  <i class="fas fa-chevron-up bounce"></i>
                 </a>
               </h2>
               <div class="panel">
@@ -1049,23 +1049,23 @@
 
                   <!--todo what is the btn-icon-only class? -->
                   <button type="button" class="btn btn-default">
-                  <i class="fa fa-comment"></i> &nbsp;Comment
+                  <i class="fas fa-comment"></i> &nbsp;Comment
                   </button>
                   <button type="button" class="btn btn-icon-only btn-default">
-                  <i class="fa fa-print"></i>
+                  <i class="fas fa-print"></i>
                   <span class="sr-only">Print</span>
                   </button>
                   <button type="button" class="btn btn-icon-only btn-primary">
-                  <i class="fa fa-inverse fa-floppy-o"></i>
+                  <i class="fas fa-inverse fa-floppy-o"></i>
                   <span class="sr-only">Save</span>
                   </button>
                   <button type="button" class="btn btn-icon-only btn-hover">
-                  <i class="fa fa-calendar-o"></i>
+                  <i class="fas fa-calendar-o"></i>
                   <span class="sr-only">Calendar</span>
                   </button>
                   <button type="button" class="btn btn-default">
                   Lock&nbsp;
-                  <i class="fa fa-arrow-right"></i>
+                  <i class="fas fa-arrow-right"></i>
                   </button>
                 </div>
               </div>
@@ -1075,7 +1075,7 @@
             <div>
               <h2 id="Cards" class="page-header">Cards
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="cards-example">
@@ -1087,7 +1087,7 @@
                         <img src="./images/cbp_super_bowl.jpg" width="330" height="157" border="0" alt="CBP Super Bowl 50 Air and Marine Operations Security" >
                       </div>
                       <div class="mdl-card__menu">
-                        <i class="fa fa-share-square fa-inverse" aria-hidden="true"></i>
+                        <i class="fas fa-share-square fa-inverse" aria-hidden="true"></i>
                       </div>
                       <div class="mdl-card__title">
                         <h3 class="mdl-card__title-text">CBP Super Bowl 50 Air and Marine Operations Security</h3>
@@ -1108,7 +1108,7 @@
                         <h2 class="mdl-card__title-text">Update</h2>
                       </div>
                       <div class="mdl-card__menu">
-                        <i class="fa fa-trash" aria-hidden="true"></i>
+                        <i class="fas fa-trash" aria-hidden="true"></i>
                       </div>
                       <div class="mdl-card__supporting-text">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -1131,11 +1131,11 @@
                         </h3>
                       </div>
                       <div class="mdl-card__menu">
-                        <i class="fa fa-times" aria-hidden="true"></i>
+                        <i class="fas fa-times" aria-hidden="true"></i>
                       </div>
                       <div class="mdl-card__actions mdl-card--border">
                         <button class="btn btn-default">
-                        <i class="fa fa-calendar fa-fw"></i>
+                        <i class="fas fa-calendar fa-fw"></i>
                         &nbsp;Calendar
                         </button>
                       </div>
@@ -1144,7 +1144,7 @@
                   <div class="col-sm-5 col-md-4">
                     <div class="mdl-card mdl-card-shadow">
                       <div class="mdl-card__title mdl-card--expand">
-                        <h2 class="mdl-card__title-text"><i class="fa fa-newspaper-o fa-fw " aria-hidden="true"></i>&nbsp; Latest News</h2>
+                        <h2 class="mdl-card__title-text"><i class="fas fa-newspaper-o fa-fw " aria-hidden="true"></i>&nbsp; Latest News</h2>
                       </div>
                       <div class="mdl-card__supporting-text">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -1165,7 +1165,7 @@
             <div>
               <h2 id="Dialogs" class="page-header">Dialogs
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -1309,7 +1309,7 @@
             <div>
               <h2 id="Form Controls" class="page-header">Form Controls
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -1715,19 +1715,19 @@
                     <div class="row">
                       <form role="form" class="col-sm-12 form-horizontal">
                         <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                          <label for="dp1" class="mdl-textfield__label"><span class="fa fa-calendar-o fa-fw"></span>&nbsp;Date</label>
+                          <label for="dp1" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;Date</label>
                           <input id="dp1" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " type="text" class="datepicker mdl-textfield__input">
                         </div>
                         <div class="row">
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="dp2" class="mdl-textfield__label"><span class="fa fa-calendar-o fa-fw"></span>&nbsp;To</label>
+                              <label for="dp2" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;To</label>
                               <input id="dp2" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="dp3" class="mdl-textfield__label"><span class="fa fa-calendar-o fa-fw"></span>&nbsp;From</label>
+                              <label for="dp3" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;From</label>
                               <input id="dp3" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
@@ -1740,19 +1740,19 @@
                     <div class="row">
                       <form role="form" class="col-sm-12 form-horizontal">
                         <div class="mdl-textfield mdl-js-textfield">
-                          <label for="dp4" class="mdl-textfield__label"><span class="fa fa-calendar-o fa-fw"></span>&nbsp;Date</label>
+                          <label for="dp4" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;Date</label>
                           <input id="dp4" data-inputmask=" 'alias' : 'mdl-mask-datepicker-placeholder' " type="text" class="datepicker mdl-textfield__input">
                         </div>
                         <div class="row">
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield">
-                              <label for="dp5" class="mdl-textfield__label"><span class="fa fa-calendar-o fa-fw"></span>&nbsp;To</label>
+                              <label for="dp5" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;To</label>
                               <input id="dp5" data-inputmask=" 'alias' : 'mdl-mask-datepicker-placeholder' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield">
-                              <label for="dp6" class="mdl-textfield__label"><span class="fa fa-calendar-o fa-fw"></span>&nbsp;From</label>
+                              <label for="dp6" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;From</label>
                               <input id="dp6" data-inputmask=" 'alias' : 'mdl-mask-datepicker-placeholder' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
@@ -1768,7 +1768,7 @@
             <div>
               <h2 id="Forms" class="page-header">Forms
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -1797,27 +1797,27 @@
                     <div class="mdl-textfield mdl-js-textfield mdl-textfield--full-width is-required">
                       <input class="mdl-textfield__input" type="text" pattern="[A-Z,a-z]*" id="sample1999" aria-required="true" />
                       <label class="mdl-textfield__label static-label" for="sample1999">static-label <span class="required-field"></span></label>
-                      <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
+                      <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
                     </div>
                     <div class="mdl-textfield mdl-js-textfield mdl-textfield--full-width is-required">
                       <input class="mdl-textfield__input" type="text" pattern="[A-Z,a-z]*" id="sample2999" aria-required="true" />
                       <label class="mdl-textfield__label" for="sample2999">placeholder label <span class="required-field"></span></label>
-                      <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
+                      <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
                     </div>
                     <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-textfield--full-width is-required">
                       <input class="mdl-textfield__input" type="text" pattern="[A-Z,a-z]*" id="sample3999" aria-required="true">
                       <label class="mdl-textfield__label" for="sample3999">floating-label <span class="required-field"></span></label>
-                      <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
+                      <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
                     </div>
                     <div class="mdl-textfield mdl-js-textfield mdl-textfield--full-width is-required">
                       <input class="mdl-textfield__input" type="text" pattern="[A-Z,a-z]*" id="sample49991" aria-required="true" disabled/>
                       <label class="mdl-textfield__label static-label" for="sample4999">static-label disabled<span class="required-field"></span></label>
-                      <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
+                      <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
                     </div>
                     <div class="mdl-textfield mdl-js-textfield mdl-textfield--full-width is-required is-readonly">
                       <input class="mdl-textfield__input" type="text" pattern="[A-Z,a-z]*" id="sample4999" aria-required="true" readonly/>
                       <label class="mdl-textfield__label static-label" for="sample4999">static-label readonly<span class="required-field"></span></label>
-                      <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
+                      <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
                     </div>
                   </form>
                   <h3>Form Validation</h3>
@@ -1826,13 +1826,13 @@
                     <div class="mdl-textfield mdl-textfield--floating-label mdl-js-textfield mdl-textfield--full-width">
                       <input class="mdl-textfield__input" type="text" pattern="[A-Z,a-z]*" id="sample11" />
                       <label class="mdl-textfield__label" for="sample11">Type any number(s) here...</label>
-                      <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
+                      <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Only alphabet and no spaces</span>
                     </div>
                     <h4>Numeric Validation</h4>
                     <div class="mdl-textfield mdl-textfield--floating-label mdl-js-textfield mdl-textfield--full-width">
                       <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="sample12" />
                       <label class="mdl-textfield__label" for="sample12">Type any alphabet(s) here...</label>
-                      <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Only numbers</span>
+                      <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Only numbers</span>
                     </div>
                   </form>
                   <h3>Help Text</h3>
@@ -1845,13 +1845,13 @@
                       <div class="mdl-textfield mdl-textfield--floating-label mdl-js-textfield mdl-textfield--full-width">
                         <label for="ht3" class="mdl-textfield__label">Full name</label>
                         <input class="mdl-textfield__input" type="text" pattern="([a-zA-Z]{3,30}\s*)+[a-zA-Z]{3,30}" id="ht3">
-                        <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Not a valid full name</span>
+                        <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Not a valid full name</span>
                       </div>
                       <div class="mdl-textfield mdl-textfield--floating-label mdl-js-textfield mdl-textfield--full-width">
                         <label for="ht48" class="mdl-textfield__label">Email</label>
                         <input class="mdl-textfield__input" type="text" pattern="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$" id="ht48">
                         <p class="mdl-textfield__help">This is how people will contact you.</p>
-                        <span class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Not a valid email address</span>
+                        <span class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Not a valid email address</span>
                       </div>
                     </div>
                   </form>
@@ -1859,10 +1859,10 @@
                   <form class="form" style="max-width: 450px;" role="form">
                     <h4>Textfield</h4>
                     <div class="mdl-textfield mdl-textfield--floating-label mdl-js-textfield mdl-textfield--full-width">
-                      <label for="ht58" class="mdl-textfield__label">Email <i class="fa fa-info-circle" aria-hidden="true"></i></label>
+                      <label for="ht58" class="mdl-textfield__label">Email <i class="fas fa-info-circle" aria-hidden="true"></i></label>
                       <input class="mdl-textfield__input" type="text" maxlength="25" data-charlimit=" 'target' : '.mdl-textfield__counter', 'limit' : 25 " pattern="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$" id="ht58">
 
-                      <p class="mdl-textfield__error"><i class="fa fa-exclamation-triangle fa-fw"></i>&nbsp;Not a valid email address</p>
+                      <p class="mdl-textfield__error"><i class="fas fa-exclamation-triangle fa-fw"></i>&nbsp;Not a valid email address</p>
                       <p class="mdl-textfield__help">This is how people will contact you.</p>
                       <p class="mdl-textfield__counter"></p>
                     </div>
@@ -1954,21 +1954,21 @@
             <div>
               <h2 id="Icons" class="page-header">Icons
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
                 <span class="fa-stack fa-lg">
-                  <i class="fa fa-circle fa-stack-2x text-success"></i>
-                  <i class="fa fa-thumbs-up fa-stack-1x fa-inverse"></i>
+                  <i class="fas fa-circle fa-stack-2x text-success"></i>
+                  <i class="fas fa-thumbs-up fa-stack-1x fa-inverse"></i>
                 </span>
                 <span class="fa-stack fa-lg">
-                  <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                  <i class="fa fa-thumbs-up fa-stack-1x fa-inverse"></i>
+                  <i class="fas fa-circle fa-stack-2x text-primary"></i>
+                  <i class="fas fa-thumbs-up fa-stack-1x fa-inverse"></i>
                 </span>
                 <span class="fa-stack fa-lg">
-                  <i class="fa fa-circle fa-stack-2x"></i>
-                  <i class="fa fa-thumbs-up fa-stack-1x fa-inverse"></i>
+                  <i class="fas fa-circle fa-stack-2x"></i>
+                  <i class="fas fa-thumbs-up fa-stack-1x fa-inverse"></i>
                 </span>
 
                 <p><a href="https://us-cbp.github.io/cbp-style-guide/docs/foundation/icons.html" target="_blank"><span class="sr-only">Link opens in new window</span>See CBP style guide for more icons examples</a>
@@ -1984,7 +1984,7 @@
             <div>
               <h2 id="Labels and Badges" class="page-header">Labels and Badges
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2014,7 +2014,7 @@
             <div>
               <h2 id="List Group" class="page-header">List Group
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2050,7 +2050,7 @@
             <div>
               <h2 id="Menus" class="page-header">Menus
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2074,12 +2074,12 @@
                     <li role="presentation" class="divider"></li>
                     <li role="presentation">
                       <a href="">Font
-                        <i class="fa fa-caret-right pull-right"></i>
+                        <i class="fas fa-caret-right pull-right"></i>
                       </a>
                     </li>
                     <li role="presentation">
                       <a href="">Font size
-                        <i class="fa fa-caret-right pull-right"></i>
+                        <i class="fas fa-caret-right pull-right"></i>
                       </a>
                     </li>
                     <li role="presentation" class="divider"></li>
@@ -2095,12 +2095,12 @@
                   <ul style="display: inline-block; position: relative; float: none; width: 200px;" class="dropdown-menu" role="menu">
                     <li role="presentation">
                       <a href="">Submenu item
-                        <i class="fa fa-caret-right pull-right"></i>
+                        <i class="fas fa-caret-right pull-right"></i>
                       </a>
                     </li>
                     <li role="presentation" class="disabled">
                       <a href="">Disabled submenu item
-                        <i class="fa fa-caret-right pull-right"></i>
+                        <i class="fas fa-caret-right pull-right"></i>
                       </a>
                     </li>
                   </ul>
@@ -2108,7 +2108,7 @@
                   <ul style="display: inline-block; position: relative; float: none; width: 200px;" class="dropdown-menu has-icon" role="menu">
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw fa-star dropdown-menu-icon"></i> &nbsp; Star
+                        <i class="fas fa-fw fa-star dropdown-menu-icon"></i> &nbsp; Star
                       </a>
                     </li>
                     <li role="presentation">
@@ -2117,7 +2117,7 @@
                     <li class="divider" role="presentation"></li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw fa-trash-o dropdown-menu-icon"></i> &nbsp; Remove
+                        <i class="fas fa-fw fa-trash-o dropdown-menu-icon"></i> &nbsp; Remove
                       </a>
                     </li>
                   </ul>
@@ -2126,34 +2126,34 @@
                     <li class="dropdown-header">Single-select</li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw dropdown-menu-icon"></i> &nbsp; 1.0
+                        <i class="fas fa-fw dropdown-menu-icon"></i> &nbsp; 1.0
                       </a>
                     </li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw fa-check dropdown-menu-icon"></i> &nbsp; 1.5
+                        <i class="fas fa-fw fa-check dropdown-menu-icon"></i> &nbsp; 1.5
                       </a>
                     </li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw dropdown-menu-icon"></i> &nbsp; 2.0
+                        <i class="fas fa-fw dropdown-menu-icon"></i> &nbsp; 2.0
                       </a>
                     </li>
                     <li class="divider" role="presentation"></li>
                     <li class="dropdown-header">Multi-select</li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw fa-check dropdown-menu-icon"></i> &nbsp; Grid lines
+                        <i class="fas fa-fw fa-check dropdown-menu-icon"></i> &nbsp; Grid lines
                       </a>
                     </li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw fa-check dropdown-menu-icon"></i> &nbsp; Rulers
+                        <i class="fas fa-fw fa-check dropdown-menu-icon"></i> &nbsp; Rulers
                       </a>
                     </li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fa fa-fw dropdown-menu-icon"></i> &nbsp; Margins
+                        <i class="fas fa-fw dropdown-menu-icon"></i> &nbsp; Margins
                       </a>
                     </li>
                   </ul>
@@ -2165,7 +2165,7 @@
             <div>
               <h2 id="Meta Data" class="page-header">Meta Data
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
                 <h3>Stacked</h3>
@@ -2196,7 +2196,7 @@
                         <dt>Port of Entry</dt>
                         <dd>
                         <a href="#">
-                          5206 <i class="fa fa-external-link"></i>
+                          5206 <i class="fas fa-external-link"></i>
                         </a>
                         </dd>
                         <dt>Importer</dt>
@@ -2213,7 +2213,7 @@
                           <dt>Shipment</dt>
                           <dd>
                           <a href="">
-                            5004672569 <i class="fa fa-external-link"></i>
+                            5004672569 <i class="fas fa-external-link"></i>
                           </a>
                           </dd>
                         </dl>
@@ -2244,7 +2244,7 @@
                           <dd>
                           <a href="">
                             5206
-                            <i class="fa fa-external-link"></i>
+                            <i class="fas fa-external-link"></i>
                           </a>
                           </dd>
                           <dt>Importer</dt>
@@ -2273,7 +2273,7 @@
             <div>
               <h2 id="Pagination" class="page-header">Pagination
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2304,7 +2304,7 @@
                   <div class="form-group">
                     <div class="btn-group">
                       <a class="btn btn-default" href="#">
-                        <i class="fa fa-angle-left"></i>
+                        <i class="fas fa-angle-left"></i>
                       </a>
                       <a class="btn btn-default" href="#">1</a>
                       <a class="btn btn-default" href="#">...</a>
@@ -2316,7 +2316,7 @@
                       <a class="btn btn-default" href="#">...</a>
                       <a class="btn btn-default" href="#">25</a>
                       <a class="btn btn-default" href="#">
-                        <i class="fa fa-angle-right"></i>
+                        <i class="fas fa-angle-right"></i>
                       </a>
                     </div>
                   </div>
@@ -2337,13 +2337,13 @@
                     <div class="form-group dropdown">
                       <div class="btn-group">
                         <a href="#" class="btn btn-default">
-                          <i class="fa fa-angle-left"></i>
+                          <i class="fas fa-angle-left"></i>
                         </a>
                         <a class="btn btn-default dropdown-toggle" id="dropdownMenu6" data-toggle="dropdown" href="">
                           15/25 <span class="caret"></span>
                         </a>
                         <a href="#" class="btn btn-default">
-                          <i class="fa fa-angle-right"></i>
+                          <i class="fas fa-angle-right"></i>
                         </a>
                         <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu6">
                           <li class="divider"></li>
@@ -2383,7 +2383,7 @@
             <div>
               <h2 id="Popovers" class="page-header">Popovers
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2404,11 +2404,11 @@
                       </div>
                       <div class="popover-toolbar">
                         <button class="btn btn-hover btn-icon-only">
-                        <i class="fa fa-image"></i>
+                        <i class="fas fa-image"></i>
                         <span class="sr-only">Add image</span>
                         </button>
                         <button class="btn btn-hover btn-icon-only">
-                        <i class="fa fa-chain"></i>
+                        <i class="fas fa-chain"></i>
                         <span class="sr-only">Add link</span>
                         </button>
                         <button class="btn btn-primary pull-right">Add</button>
@@ -2450,7 +2450,7 @@
             <div>
               <h2 id="Progress and Loading" class="page-header">Progress and Loading
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2467,17 +2467,17 @@
                   <h3>Load Spinners</h3>
                   <button class="btn btn-default">Load more</button>
                   <button class="btn btn-default" disabled>
-                  <i class="fa fa-spinner fa-pulse"></i> Loading...
+                  <i class="fas fa-spinner fa-pulse"></i> Loading...
                   </button>
                   <p></p>
                   <button aria-label="favorite_button_label" class="btn btn-default btn-icon-only">
-                  <i class="fa fa-star-o"></i>
+                  <i class="fas fa-star-o"></i>
                   </button>
                   <button aria-label="disabled_button_label" class="btn btn-default btn-icon-only" disabled>
-                  <i class="fa fa-spinner fa-pulse"></i>
+                  <i class="fas fa-spinner fa-pulse"></i>
                   </button>
                   <button aria-label="favorite_button_label2" class="btn btn-default btn-icon-only">
-                  <i class="fa fa-star"></i>
+                  <i class="fas fa-star"></i>
                   </button>
                   <p></p>
                   <div style="position: relative; padding: 40px; background: #fff;">
@@ -2529,7 +2529,7 @@
                       </tbody>
                     </table>
                     <div class="loading-box text-center text-muted">
-                      <i class="fa fa-spinner fa-pulse fa-fw"></i>&nbsp;Loading...
+                      <i class="fas fa-spinner fa-pulse fa-fw"></i>&nbsp;Loading...
                     </div>
                   </div>
                 </div>
@@ -2540,7 +2540,7 @@
             <div>
               <h2 id="Banners" class="page-header">Security Classification Banners
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2561,7 +2561,7 @@
             <div>
               <h2 id="Step Indicators" class="page-header">Step Indicators
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2617,7 +2617,7 @@
             <div>
               <h2 id="Tables" class="page-header">Tables
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2682,7 +2682,7 @@
             <div>
               <h2 id="Tabs" class="page-header">Tabs
               <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                <i class="fa fa-chevron-up bounce"></i>
+                <i class="fas fa-chevron-up bounce"></i>
               </a>
               </h2>
               <div class="panel">
@@ -2797,7 +2797,7 @@
             <div>
               <h2 id="Tags" class="page-header">Tags
                 <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                  <i class="fa fa-chevron-up bounce"></i>
+                  <i class="fas fa-chevron-up bounce"></i>
                 </a>
               </h2>
 
@@ -2807,31 +2807,31 @@
                   <ul class="list-unstyled">
                     <li class="tag tag-default">
                       Default
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-inverse">
                       Inverse
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-primary">
                       Primary
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-info">
                       Info
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-warning">
                       Warning
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-danger">
                       Danger
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-success">
                       Success
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                   </ul>
                 </div>
@@ -2843,27 +2843,27 @@
                   <ul class="list-unstyled">
                     <li class="tag tag-default subtle">
                       Default
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-primary subtle">
                       Primary
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-info subtle">
                       Info
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-warning subtle">
                       Warning
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-danger subtle">
                       Danger
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                     <li class="tag tag-success subtle">
                       Success
-                      <a href="#Tags" class="fa fa-close fa-muted" data-dismiss="tag"></a>
+                      <a href="#Tags" class="fas fa-close fa-muted" data-dismiss="tag"></a>
                     </li>
                   </ul>
                 </div>
@@ -2874,7 +2874,7 @@
             <div>
               <h2 id="Timelines" class="page-header">Timelines
                 <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                  <i class="fa fa-chevron-up"></i>
+                  <i class="fas fa-chevron-up"></i>
                 </a>
               </h2>
               <div class="panel">
@@ -2899,9 +2899,9 @@
                           <!-- timeline item -->
                           <li>
                               <!-- timeline icon -->
-                              <i class="fa fa-envelope"></i>
+                              <i class="fas fa-envelope"></i>
                               <div class="timeline-item">
-                                  <span class="time"><i class="fa fa-clock-o"></i> 12:05</span>
+                                  <span class="time"><i class="fas fa-clock-o"></i> 12:05</span>
 
                                   <h3 class="timeline-header"><a href="#">Event #1</a> ...</h3>
 
@@ -2937,7 +2937,7 @@
                               <!-- timeline icon -->
                               <i class="timepoint-text">Event 1</i>
                               <div class="timeline-item">
-                                  <span class="time"><i class="fa fa-clock-o"></i> 12:15</span>
+                                  <span class="time"><i class="fas fa-clock-o"></i> 12:15</span>
 
                                   <h3 class="timeline-header"><a href="#">Event with no icon</a> ...</h3>
 
@@ -2955,7 +2955,7 @@
                           <!-- END timeline item -->
 
                           <li>
-                            <i class="fa fa-clock-o"></i>
+                            <i class="fas fa-clock-o"></i>
                           </li>
                         </ul>
                       </div>
@@ -2978,9 +2978,9 @@
 
 
                           <li>
-                            <i class="fa fa-files-o"></i>
+                            <i class="fas fa-files-o"></i>
                             <div class="timeline-item">
-                              <span class="time">2 filings <i class="fa fa-info-circle"></i></span>
+                              <span class="time">2 filings <i class="fas fa-info-circle"></i></span>
 
                               <h3 class="timeline-header no-border"><a href="#">Trade Filings</a></h3>
 
@@ -2991,36 +2991,36 @@
                           </li>
 
                           <li>
-                            <i class="fa fa-truck"></i>
+                            <i class="fas fa-truck"></i>
                             <div class="timeline-item">
-                              <span class="time">Port 1234 to Port 4321 <i class="fa fa-info-circle"></i></span>
+                              <span class="time">Port 1234 to Port 4321 <i class="fas fa-info-circle"></i></span>
 
                               <h3 class="timeline-header no-border"><a href="#">Cargo Movement</a></h3>
                             </div>
                           </li>
 
                           <li>
-                            <i class="fa fa-cogs"></i>
+                            <i class="fas fa-cogs"></i>
                             <div class="timeline-item">
-                              <span class="time text-danger">* 53 system events <i class="fa fa-info-circle"></i></span>
+                              <span class="time text-danger">* 53 system events <i class="fas fa-info-circle"></i></span>
 
                               <h3 class="timeline-header no-border"><a href="#">Internal Events</a></h3>
                             </div>
                           </li>
 
                           <li>
-                            <i class="fa fa-sticky-note-o"></i>
+                            <i class="fas fa-sticky-note-o"></i>
                             <div class="timeline-item">
-                              <span class="time">7 related notes <i class="fa fa-info-circle"></i></span>
+                              <span class="time">7 related notes <i class="fas fa-info-circle"></i></span>
 
                               <h3 class="timeline-header no-border"><a href="#">Notes</a></h3>
                             </div>
                           </li>
 
                           <li>
-                            <i class="fa fa-user"></i>
+                            <i class="fas fa-user"></i>
                             <div class="timeline-item">
-                              <span class="time">3 actions <i class="fa fa-info-circle"></i></span>
+                              <span class="time">3 actions <i class="fas fa-info-circle"></i></span>
 
                               <h3 class="timeline-header no-border"><a href="#">CBP Officer Action</a></h3>
                             </div>
@@ -3037,9 +3037,9 @@
 
 
                           <li>
-                            <i class="fa fa-circle-o-notch"></i>
+                            <i class="fas fa-circle-o-notch"></i>
                             <div class="timeline-item">
-                              <span class="time">1 event <i class="fa fa-info-circle"></i></span>
+                              <span class="time">1 event <i class="fas fa-info-circle"></i></span>
 
                               <h3 class="timeline-header no-border"><a href="#">Post Release</a></h3>
                             </div>
@@ -3047,7 +3047,7 @@
 
 
                           <li>
-                            <i class="fa fa-clock-o"></i>
+                            <i class="fas fa-clock-o"></i>
                           </li>
                         </ul>
                       </div>
@@ -3074,10 +3074,10 @@
 
                           <!-- timeline item -->
                           <li>
-                            <i class="fa fa-envelope"></i>
+                            <i class="fas fa-envelope"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fa fa-clock-o"></i> 12:05</span>
+                              <span class="time"><i class="fas fa-clock-o"></i> 12:05</span>
 
                               <h3 class="timeline-header"><a href="#">Event #1</a> sent you an email</h3>
 
@@ -3094,10 +3094,10 @@
 
                           <!-- timeline item -->
                           <li>
-                            <i class="fa fa-user"></i>
+                            <i class="fas fa-user"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fa fa-clock-o"></i> 5 mins ago</span>
+                              <span class="time"><i class="fas fa-clock-o"></i> 5 mins ago</span>
 
                               <h3 class="timeline-header no-border"><a href="#">Sarah Young</a> accepted your friend request</h3>
                             </div>
@@ -3106,10 +3106,10 @@
 
                           <!-- timeline item -->
                           <li>
-                            <i class="fa fa-comments"></i>
+                            <i class="fas fa-comments"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fa fa-clock-o"></i> 27 mins ago</span>
+                              <span class="time"><i class="fas fa-clock-o"></i> 27 mins ago</span>
 
                               <h3 class="timeline-header"><a href="#">Jay White</a> commented on your post</h3>
 
@@ -3133,10 +3133,10 @@
 
                           <!-- timeline item -->
                           <li>
-                            <i class="fa fa-camera"></i>
+                            <i class="fas fa-camera"></i>
 
                             <div class="timeline-item">
-                              <span class="time"><i class="fa fa-clock-o"></i> 2 days ago</span>
+                              <span class="time"><i class="fas fa-clock-o"></i> 2 days ago</span>
 
                               <h3 class="timeline-header"><a href="#">Mina Lee</a> uploaded new photos</h3>
 
@@ -3151,7 +3151,7 @@
                           <!-- END timeline item -->
 
                           <li>
-                            <i class="fa fa-clock-o"></i>
+                            <i class="fas fa-clock-o"></i>
                           </li>
                         </ul>
                       </div>
@@ -3168,7 +3168,7 @@
             <div>
               <h2 id="Tooltips" class="page-header">Tooltips
                 <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                  <i class="fa fa-chevron-up bounce"></i>
+                  <i class="fas fa-chevron-up bounce"></i>
                 </a>
               </h2>
               <div class="panel">
@@ -3188,7 +3188,7 @@
                       <div>
                         <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Print">Short</button>
                         <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" data-html="true" title='Lorem ipsum dolor sit amet, consectetur adipiscing elit. In semper volutpat ultrices. Mauris lobortis lacus vel ullamcorper vestibulum.'>Wrapping</button>
-                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" data-html="true" title='<i class="fa fa-inverse fa-calendar-o"></i> <strong>January 21</strong> , 2014'>
+                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" data-html="true" title='<i class="fas fa-inverse fa-calendar-o"></i> <strong>January 21</strong> , 2014'>
                           Rich content
                         </button>
                       </div>
@@ -3202,7 +3202,7 @@
             <div>
               <h2 id="Typography" class="page-header">Typography
                 <a href="#content" class="pull-right circle-btn return-to-top-btn" title="Back to Top" data-toggle="tooltip" data-placement="left">
-                  <i class="fa fa-chevron-up"></i>
+                  <i class="fas fa-chevron-up"></i>
                 </a>
               </h2>
               <div class="panel">

--- a/kitchensink/index.html
+++ b/kitchensink/index.html
@@ -16,6 +16,7 @@
 
     <!-- CUSTOM CSS ONLY FOR THIS KITCHEN SINK -->
     <link media="screen" href="./kitchensink.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
 
   </head>
   <body>
@@ -355,7 +356,7 @@
                       </div>
                     </div>
                     <h3 aria-expanded="true" data-toggle="collapse" role="tab" data-target="#filterGroup2" aria-controls="filterGroup2" class="filter-group-title">
-                      <a name="#cbp-sidebar"><i class="fas fa-angle-right pull-right"></i></a>
+                      <a name="#cbp-sidebar"><i class="fas fa-angle-double-right pull-right"></i></a>
                     Mode of Transportation
                     </h3>
                     <div id="filterGroup2" class="collapse in">
@@ -408,13 +409,13 @@
                         <div class="row">
                           <div class="form-group col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="startRange" class="mdl-textfield__label"><i class="fas fa-calendar-o fa-fw"></i>&nbsp;Start</label>
+                              <label for="startRange" class="mdl-textfield__label"><i class="fas fa-calendar fa-fw"></i>&nbsp;Start</label>
                               <input type="text" id="startRange" class="datepicker mdl-textfield__input" data-inputmask=" 'alias' : 'mdl-mask-datepicker'  " />
                             </div>
                           </div>
                           <div class="form-group col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="endRange" class="mdl-textfield__label"><i class="fas fa-calendar-o fa-fw"></i>&nbsp;End</label>
+                              <label for="endRange" class="mdl-textfield__label"><i class="fas fa-calendar fa-fw"></i>&nbsp;End</label>
                               <input type="text" id="endRange" class="datepicker mdl-textfield__input" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " />
                             </div>
                           </div>
@@ -668,7 +669,7 @@
                     <div class="panel">
                       <div class="panel-heading" role="tab" id="2headingOne">
                         <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseOne" aria-expanded="true" aria-controls="2collapseOne"><i class="fas fa-angle-right fa-fw"></i>
+                        <a role="button" data-toggle="collapse" data-parent="#2accordion" href="#2collapseOne" aria-expanded="true" aria-controls="2collapseOne"><i class="fas fa-angle-right"></i>
                         Goods/Services</a>
                         </h4>
                       </div>
@@ -771,7 +772,7 @@
                     <span aria-hidden="true">&times;</span>
                     <span class="sr-only">Close</span>
                     </button>
-                    <i class="alert-icon-info alert-icon" aria-hidden="true"></i><span class="sr-only">Info alert</span> Press the <strong>'A'</strong> key to automatically assign a case.
+                    <i class=" alert-icon alert-icon-info" aria-hidden="true"></i><span class="sr-only">Info alert</span> Press the <strong>'A'</strong> key to automatically assign a case.
                   </div>
                   <div class="alert alert-success" role="alert" aria-live="polite">
                     <button type="button" class="close">
@@ -1056,11 +1057,11 @@
                   <span class="sr-only">Print</span>
                   </button>
                   <button type="button" class="btn btn-icon-only btn-primary">
-                  <i class="fas fa-inverse fa-floppy-o"></i>
+                  <i class="fas fa-save"></i>
                   <span class="sr-only">Save</span>
                   </button>
                   <button type="button" class="btn btn-icon-only btn-hover">
-                  <i class="fas fa-calendar-o"></i>
+                  <i class="fas fa-calendar"></i>
                   <span class="sr-only">Calendar</span>
                   </button>
                   <button type="button" class="btn btn-default">
@@ -1144,7 +1145,7 @@
                   <div class="col-sm-5 col-md-4">
                     <div class="mdl-card mdl-card-shadow">
                       <div class="mdl-card__title mdl-card--expand">
-                        <h2 class="mdl-card__title-text"><i class="fas fa-newspaper-o fa-fw " aria-hidden="true"></i>&nbsp; Latest News</h2>
+                        <h2 class="mdl-card__title-text"><i class="fas fa-newspaper fa-fw " aria-hidden="true"></i>&nbsp; Latest News</h2>
                       </div>
                       <div class="mdl-card__supporting-text">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -1715,19 +1716,19 @@
                     <div class="row">
                       <form role="form" class="col-sm-12 form-horizontal">
                         <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                          <label for="dp1" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;Date</label>
+                          <label for="dp1" class="mdl-textfield__label"><span class="fas fa-calendar fa-fw"></span>&nbsp;Date</label>
                           <input id="dp1" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " type="text" class="datepicker mdl-textfield__input">
                         </div>
                         <div class="row">
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="dp2" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;To</label>
+                              <label for="dp2" class="mdl-textfield__label"><span class="fas fa-calendar fa-fw"></span>&nbsp;To</label>
                               <input id="dp2" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                              <label for="dp3" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;From</label>
+                              <label for="dp3" class="mdl-textfield__label"><span class="fas fa-calendar fa-fw"></span>&nbsp;From</label>
                               <input id="dp3" data-inputmask=" 'alias' : 'mdl-mask-datepicker' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
@@ -1740,19 +1741,19 @@
                     <div class="row">
                       <form role="form" class="col-sm-12 form-horizontal">
                         <div class="mdl-textfield mdl-js-textfield">
-                          <label for="dp4" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;Date</label>
+                          <label for="dp4" class="mdl-textfield__label"><span class="fas fa-calendar fa-fw"></span>&nbsp;Date</label>
                           <input id="dp4" data-inputmask=" 'alias' : 'mdl-mask-datepicker-placeholder' " type="text" class="datepicker mdl-textfield__input">
                         </div>
                         <div class="row">
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield">
-                              <label for="dp5" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;To</label>
+                              <label for="dp5" class="mdl-textfield__label"><span class="fas fa-calendar fa-fw"></span>&nbsp;To</label>
                               <input id="dp5" data-inputmask=" 'alias' : 'mdl-mask-datepicker-placeholder' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
                           <div class="col-sm-6">
                             <div class="mdl-textfield mdl-js-textfield">
-                              <label for="dp6" class="mdl-textfield__label"><span class="fas fa-calendar-o fa-fw"></span>&nbsp;From</label>
+                              <label for="dp6" class="mdl-textfield__label"><span class="fas fa-calendar fa-fw"></span>&nbsp;From</label>
                               <input id="dp6" data-inputmask=" 'alias' : 'mdl-mask-datepicker-placeholder' " type="text" class="datepicker mdl-textfield__input">
                             </div>
                           </div>
@@ -2117,7 +2118,7 @@
                     <li class="divider" role="presentation"></li>
                     <li role="presentation">
                       <a href="">
-                        <i class="fas fa-fw fa-trash-o dropdown-menu-icon"></i> &nbsp; Remove
+                        <i class="fas fa-fw fa-trash dropdown-menu-icon"></i> &nbsp; Remove
                       </a>
                     </li>
                   </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,7 +3041,7 @@
     },
     "eslint": {
       "version": "4.19.1",
-      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
@@ -3113,9 +3113,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "version": "3.12.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+          "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -3559,7 +3559,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -3653,7 +3653,7 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
@@ -3833,9 +3833,9 @@
       }
     },
     "font-awesome": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.6.3.tgz",
-      "integrity": "sha1-hpM2UVQO4Ah0xmQBf1DyFy9lMaI="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "for-in": {
       "version": "1.0.2",
@@ -9932,7 +9932,7 @@
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,11 @@
         }
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.6.3.tgz",
+      "integrity": "sha512-s5PLdI9NYgjBvfrv6rhirPHlAHWx+Sfo/IjsAeiXYfmemC/GSjwsyz1wLnGPazbLPXWfk62ks980o9AmsxYUEQ=="
+    },
     "@types/acorn": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.4.tgz",
@@ -3831,11 +3836,6 @@
           }
         }
       }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "parser": "babel-eslint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "5.6.3",
     "bootstrap-sass": "3.3.7",
-    "font-awesome": "4.7.0",
     "jquery": "3.3.1",
     "material-design-lite": "1.1.1",
     "mdl-selectfield": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "dependencies": {
     "bootstrap-sass": "3.3.7",
-    "font-awesome": "4.6.3",
+    "font-awesome": "4.7.0",
     "jquery": "3.3.1",
     "material-design-lite": "1.1.1",
     "mdl-selectfield": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "parser": "babel-eslint"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "5.6.3",
     "bootstrap-sass": "3.3.7",
     "jquery": "3.3.1",
+    "@fortawesome/fontawesome-free": "5.6.3",
     "material-design-lite": "1.1.1",
     "mdl-selectfield": "1.0.2",
     "roboto-fontface": "0.10.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ function getCommonOptions (input, name, excludeExternal) {
     aliases: {
       '$': 'jquery',
       './dependencyLibs/inputmask.dependencyLib': path.join(projectRoot, 'node_modules/inputmask/dist/inputmask/dependencyLibs/inputmask.dependencyLib.jquery.js'),
-      'bootstrap': path.join(projectRoot, 'node_modules/bootstrap/dist/js/bootstrap.js')
+      'bootstrap': path.join(projectRoot, 'node_modules/bootstrap/dist/js/bootstrap.js'),
     }
   }
 }

--- a/src/styles/custom/_accordions.scss
+++ b/src/styles/custom/_accordions.scss
@@ -3,10 +3,10 @@
 .filter-list[role="tablist"] > .filter-group-title {
     cursor: pointer;
 
-    &[aria-expanded="false"] .fa.fa-angle-right {
+    &[aria-expanded="false"] .fas.fa-angle-right {
         @include transition(all 0.25s linear);
     }
-    &[aria-expanded="true"] .fa.fa-angle-right {
+    &[aria-expanded="true"] .fas.fa-angle-right {
         @include transition(all 0.25s linear);
         @include transform(rotate(90deg));
     }

--- a/src/styles/custom/_alerts.scss
+++ b/src/styles/custom/_alerts.scss
@@ -48,7 +48,7 @@
 }
 
 .alert-icon-warning {
-    @extend .fa-warning ;
+    @extend .fa-exclamation-circle ;
 }
 
 .toast-list {

--- a/src/styles/custom/_alerts.scss
+++ b/src/styles/custom/_alerts.scss
@@ -35,20 +35,19 @@
     }
 }
 .alert-icon-info{
-    @extend .fa-info-circle;
+    @extend .fa-info;
 }
 
-
 .alert-icon-success {
-    @extend .fa-check ;
+    @extend .fa-check;
 }
 
 .alert-icon-danger {
-    @extend .fa-times-circle ;
+    @extend .fa-times-circle;
 }
 
 .alert-icon-warning {
-    @extend .fa-exclamation-circle ;
+    @extend .fa-exclamation-triangle;
 }
 
 .toast-list {

--- a/src/styles/custom/_alerts.scss
+++ b/src/styles/custom/_alerts.scss
@@ -18,7 +18,7 @@
     }
 
     .alert-icon {
-        @extend .fa;
+        @extend .fas;
         margin-right: 3px;
         width: 18px;
         margin-left: -4px;

--- a/src/styles/custom/_buttons.scss
+++ b/src/styles/custom/_buttons.scss
@@ -23,11 +23,11 @@
 }
 
 // FA icons only look good at 13px.
-.btn .fa {
+.btn .fas {
   font-size: $font-size-base;
 }
 
-.input-group-lg .btn .fa {
+.input-group-lg .btn .fas {
   font-size: 18px;
 }
 

--- a/src/styles/custom/_globals.scss
+++ b/src/styles/custom/_globals.scss
@@ -1,6 +1,8 @@
-body {
-  /* padding-top: 50px;
-  padding-bottom: 50px; */
+@import './_metadata';
+
+.fa, .fas, .far {
+  font-family: "Font Awesome\ 5 Free"!important;
+  font-weight: 900!important;
 }
 
 .toolbar-text {
@@ -8,9 +10,6 @@ body {
     display: inline-block;
     vertical-align: middle;
 }
-
-
-@import './_metadata';
 
 a:focus,
 button:focus,
@@ -86,7 +85,8 @@ input[type=radio]:focus
       + li:before{
       // extending .fa doesnt seem to work!!!
         display: inline-block;
-        font: normal normal normal $font-size-base/1 FontAwesome;
+        font: normal normal normal $font-size-base/1 "Font Awesome\ 5 Free";
+        font-weight: 900!important;
         font-size: inherit;
         text-rendering: auto;
         @include antialiasing(antialiased);

--- a/src/styles/custom/_globals.scss
+++ b/src/styles/custom/_globals.scss
@@ -91,7 +91,7 @@ input[type=radio]:focus
         text-rendering: auto;
         @include antialiasing(antialiased);
 
-        @extend .fa:before !optional;
+        @extend .fas:before !optional;
         @extend .fa-angle-right:before;
 
         color: $gray-darker;

--- a/src/styles/custom/_navbar.scss
+++ b/src/styles/custom/_navbar.scss
@@ -33,7 +33,7 @@ $dropdownMenu-content: 5px;
   }
 
   &-nav > li > a > .glyphicon,
-  &-nav > li > a > .fa {
+  &-nav > li > a > .fas {
     line-height: 0;
     top: 2px;
     padding: 0 2px;

--- a/src/styles/custom/_navbar.scss
+++ b/src/styles/custom/_navbar.scss
@@ -395,12 +395,14 @@ $dropdownMenu-content: 5px;
       @include header-collapse-btn();
 
       &.collapsed::before {
-        font-family: FontAwesome;
-      content: "\f0c9 \00a0\00a0 Menu";
+        font-family: "Font Awesome\ 5 Free";
+        content: "\f0c9 \00a0\00a0 Menu";
+        font-weight: 900;
       }
       &::before {
-        font-family: FontAwesome;
-      content: "\f00d \00a0\00a0 Close";
+        font-family: "Font Awesome\ 5 Free";
+        content: "\f00d \00a0\00a0 Close";
+        font-weight: 900;
       }
     }
 

--- a/src/styles/custom/_timelines.scss
+++ b/src/styles/custom/_timelines.scss
@@ -63,7 +63,7 @@
 
     }
 
-    > .fa,
+    > .fas,
     > .glyphicon,
     > .timepoint-text {
       font-size: 15px;
@@ -75,7 +75,7 @@
     }
 
     // The icons
-    > .fa,
+    > .fas,
     > .glyphicon {
       width: 30px;
       left: 18px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -18,8 +18,8 @@
 $roboto-font-path: 'roboto-fontface/fonts' !default;
 @import "vendor/roboto";
 
-$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
-@import "@fortawesome/fontawesome-free/css/fontawesome";
+//$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !important;
+@import "@fortawesome/fontawesome-free/scss/fontawesome";
 
 @import "vendor/select2_mdl_theme";
 @import "vendor/selectize_mdl_theme";

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -18,8 +18,8 @@
 $roboto-font-path: 'roboto-fontface/fonts' !default;
 @import "vendor/roboto";
 
-//$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !important;
-@import "@fortawesome/fontawesome-free/scss/fontawesome";
+$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
+@import "vendor/fontawesome";
 
 @import "vendor/select2_mdl_theme";
 @import "vendor/selectize_mdl_theme";

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -18,8 +18,8 @@
 $roboto-font-path: 'roboto-fontface/fonts' !default;
 @import "vendor/roboto";
 
-$fa-font-path: "font-awesome/fonts" !default;
-@import "vendor/fontawesome";
+$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
+@import "@fortawesome/fontawesome-free/css/fontawesome";
 
 @import "vendor/select2_mdl_theme";
 @import "vendor/selectize_mdl_theme";

--- a/src/styles/vendor/_datepicker.scss
+++ b/src/styles/vendor/_datepicker.scss
@@ -58,8 +58,8 @@
     }
 
     .ui-datepicker-prev .ui-icon:after, .ui-datepicker-next .ui-icon:after {
-        @extend .fa;
-        @extend .fa:after !optional;
+        @extend .fas;
+        @extend .fas:after !optional;
         margin-left: -4px;
     }
 
@@ -86,7 +86,7 @@
     }
 
     .ui-datepicker-prev {
-      @extend .fa;
+      @extend .fas;
       @extend .fa-chevron-left;
       top: 10px !important;
       left: 2px !important;
@@ -99,7 +99,7 @@
     }
 
     .ui-datepicker-next {
-      @extend .fa;
+      @extend .fas;
       @extend .fa-chevron-right;
       top: 10px !important;
       right: -14px !important;

--- a/src/styles/vendor/_fontawesome.scss
+++ b/src/styles/vendor/_fontawesome.scss
@@ -1,20 +1,7 @@
 
 
 // custom overrides!
-$fa-font-path: "~font-awesome/fonts" !default;
-@import "font-awesome/scss/variables";
+$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
+@import "@fortawesome/fontawesome-free/scss/fontawesome";
 
-
-@import "font-awesome/scss/mixins";
-@import "font-awesome/scss/path";
-@import "font-awesome/scss/core";
-@import "font-awesome/scss/larger";
-@import "font-awesome/scss/fixed-width";
-@import "font-awesome/scss/list";
-@import "font-awesome/scss/bordered-pulled";
-@import "font-awesome/scss/animated";
-@import "font-awesome/scss/rotated-flipped";
-@import "font-awesome/scss/stacked";
-@import "font-awesome/scss/icons";
-
-// last updated 03.15.2015
+// last updated 01.08.2018

--- a/src/styles/vendor/_fontawesome.scss
+++ b/src/styles/vendor/_fontawesome.scss
@@ -1,5 +1,7 @@
 // custom overrides!
-//$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
-@import "@fortawesome/fontawesome-free/css/fontawesome";
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts" !default;
+
+@import "@fortawesome/fontawesome-free/scss/solid";
+@import "@fortawesome/fontawesome-free/scss/fontawesome";
 
 // last updated 01.08.2018

--- a/src/styles/vendor/_fontawesome.scss
+++ b/src/styles/vendor/_fontawesome.scss
@@ -1,7 +1,5 @@
-
-
 // custom overrides!
-$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
-@import "@fortawesome/fontawesome-free/scss/fontawesome";
+//$fa-font-path: "@fortawesome/fontawesome-free/webfonts" !default;
+@import "@fortawesome/fontawesome-free/css/fontawesome";
 
 // last updated 01.08.2018


### PR DESCRIPTION
#### What's this PR do?
- This Adds Font Awesome 5.4.1 Support for the CBP Theme

#### Where should the reviewer start?
- I'd start by reviewing the package.json and build methods, double check the file paths, and other font-awesome custom code from version 4 that have been updated to match up with version 5

#### How should this be manually tested?
- Fire up Kitchen Sink and look out for any missing icons or such. Cross-browser check + IE 11 Check

#### Any background context you want to provide?
- In a project, we needed icons from the latest FA, that were not available in FA v4

#### What are the relevant tickets?
- none

#### Screenshots (if appropriate)
- none

#### Questions:
- Is there a blog post? Nope
- Does the knowledge base need an update? Yes. Please adhere to FA v5 [nomenclature](https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use) `.fas` prefix
